### PR TITLE
Update get_users_in_list to use export_data_api

### DIFF
--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -748,7 +748,7 @@ class IterableApi():
 
 		return self.api_call(call=call, method="GET")
 
-	def get_users_in_list(self, list_id):
+	def get_users_in_list(self, list_id, path, return_response_object=None ):
 
 		call = "/api/lists/getUsers"
 
@@ -756,7 +756,7 @@ class IterableApi():
 
 		payload["listId"]= list_id
 
-		return self.api_call(call=call, method="GET", params=payload)
+		return self.export_data_api(call=call, method="GET", params=payload, path=path, return_response_object=return_response_object )
 
 	def add_subscribers_to_list(self, list_id, subscribers):
 


### PR DESCRIPTION
@carter-j-h  The Iterable Api `/api/lists/getUsers` endpoint returns a text/plain response body containing emails separated by linefeeds.  This is causing the api_call method in client.py to crash at line 65 when it calls `.json()` as the api has not provided JSON. 

This PR modifies the `get_users_in_list` method by replacing api_call with the export_data_api method.  This will require the `get_users_in_list` method to take two new arguments `path` and `return_response_object`  

