### PR TITLE
Add retry logic on 504 errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.enabled": true
-}

--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -70,14 +70,14 @@ class IterableApi():
         r = requests_session.request(method=method, url=self.base_uri+call, params=params,
 							 headers=self.headers, data=data, json=json)
 
-        response = {
-            "body": r.json(),
-            "code": r.status_code,
-            "headers": r.headers,
-            "url": r.url
-        }
+		response = {
+			"body": r.json(),
+			"code": r.status_code,
+			"headers": r.headers,
+			"url": r.url
+		}
 
-        return response
+		return response
 
 	def export_data_api(self, call,
 						params, path,

--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -63,21 +63,28 @@ class IterableApi():
 		retries = Retry(total=5, backoff_factor=1, status_forcelist=[504])
         requests_session = requests.Session()
         requests_session.mount(
-            self.base_uri+call,
-            HTTPAdapter(max_retries=retries),
+			self.base_uri+call,
+			HTTPAdapter(max_retries=retries),
         )
 
-        r = requests_session.request(method=method, url=self.base_uri+call, params=params,
-							 headers=self.headers, data=data, json=json)
+        r = requests_session.request(
+			method=method,
+			url=self.base_uri+call,
+			params=params,
+			headers=self.headers,
+			data=data,
+			json=json
+		)
 
-		response = {
-			"body": r.json(),
-			"code": r.status_code,
-			"headers": r.headers,
-			"url": r.url
-		}
+	response = {
+		"body": r.json(),
+		"code": r.status_code,
+		"headers": r.headers,
+		"url": r.url
+	}
 
 		return response
+
 
 	def export_data_api(self, call,
 						params, path,

--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -63,21 +63,21 @@ class IterableApi():
 		retries = Retry(total=5, backoff_factor=1, status_forcelist=[504])
         requests_session = requests.Session()
         requests_session.mount(
-			self.base_uri+call,
+            self.base_uri+call,
             HTTPAdapter(max_retries=retries),
         )
 
-		r = requests_session.request(method=method, url=self.base_uri+call, params=params,
+        r = requests_session.request(method=method, url=self.base_uri+call, params=params,
 							 headers=self.headers, data=data, json=json)
 
-		response = {
-			"body": r.json(),
-			"code": r.status_code,
-			"headers": r.headers,
-			"url": r.url
-		}
+        response = {
+            "body": r.json(),
+            "code": r.status_code,
+            "headers": r.headers,
+            "url": r.url
+        }
 
-		return response
+        return response
 
 	def export_data_api(self, call,
 						params, path,


### PR DESCRIPTION
I noticed that code would error out when we call `r.json()` if  we get any 504 Gateway Timeout response from Iterable. I just added logic to retry the request when a 504 is returned