### PR TITLE
client: raise exception on HTTP error in api_call().

### DIFF
--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -60,6 +60,7 @@ class IterableApi():
 		# make the request following the 'requests.request' method
 		r = requests.request(method=method, url=self.base_uri+call, params=params,
 							 headers=self.headers, data=data, json=json)	
+		r.raise_for_status()
 
 		response = {			
 			"body": r.json(),			


### PR DESCRIPTION
this helps raise a meaningful exception on HTTP error
instead of crashing with JSONDecodeError when calling r.json().