### PR TITLE
fix: linkParams in email template update and upsert

### DIFF
--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -1048,7 +1048,7 @@ class IterableApi():
 			payload["googleAnalyticsCampaignName"]= google_analytics_campaign_name
 
 		if link_parameters is not None:
-			payload["linkParameters"]= link_parameters
+			payload["linkParams"]= link_parameters
 
 		if data_feed_id is not None:
 			payload["dataFeedId"]= data_feed_id
@@ -1126,7 +1126,7 @@ class IterableApi():
 			payload["googleAnalyticsCampaignName"]= google_analytics_campaign_name
 
 		if link_parameters is not None:
-			payload["linkParameters"]= link_parameters
+			payload["linkParams"]= link_parameters
 
 		if data_feed_id is not None:
 			payload["dataFeedId"]= data_feed_id

--- a/iterablepythonwrapper/client.py
+++ b/iterablepythonwrapper/client.py
@@ -1713,10 +1713,3 @@ class IterableApi():
 			payload["listId"]= list_id
 
 		return self.api_call(call=call, method="POST", json=payload)
-
-	
-
-
-
-
-	


### PR DESCRIPTION
The parameter name for Link Parameters in the Iterable API is `linkParams` not `linkParameters`.
Reference: https://api.iterable.com/api/docs#templates_upsertEmailTemplate